### PR TITLE
 Get Nix dependencies before starting other things 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,6 +57,10 @@ jobs:
       - name: Install Nix
         uses: cachix/install-nix-action@v17
 
+      - name: Install Nix Dependencies
+        run: |
+          nix develop --command true
+
       - name: Build Website
         run: |
           nix develop --command make website
@@ -135,6 +139,10 @@ jobs:
 
       - name: Install Nix
         uses: cachix/install-nix-action@v17
+
+      - name: Install Nix Dependencies
+        run: |
+          nix develop --command true
 
       - name: Build Test Website
         run: |


### PR DESCRIPTION
That way, the CI will report nicer numbers.