### PR TITLE
Fix the handling of trivial files in the `Makefile`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,7 @@ $(website-output)/dances.raw.json: $(addsuffix .raw.json, $(built_dances))
 	  jq -s 'map({(.slug): (.dance)}) | .+[{}] | add | {dances:.}' $^ > $@
 	else
 	  printf '  => trivial file because no built dances\n'
-	  jq -n '{dances:[]}' > $@
+	  jq -n '{dances:{}}' > $@
 	fi
 
 $(website-output)/dances.json: $(website-output)/dances.raw.json
@@ -251,7 +251,7 @@ $(website-output)/tunes.raw.json: $(addsuffix .raw.json, $(built_tunes))
 	  jq -s 'map({(.slug): (.tune)}) | .+[{}] | add | {tunes:., root:"."}' $^ > $@
 	else
 	  printf '  => trivial file because no built tunes\n'
-	  jq -n '{tunes:[], root:"."}' > $@
+	  jq -n '{tunes:{}, root:"."}' > $@
 	fi
 
 $(website-output)/tunes.json: $(website-output)/tunes.raw.json

--- a/Makefile
+++ b/Makefile
@@ -162,6 +162,7 @@ $(website-output)/dances.raw.json: $(addsuffix .raw.json, $(built_dances))
 	  jq -s 'map({(.slug): (.dance)}) | .+[{}] | add | {dances:.}' $^ > $@
 	else
 	  printf '  => trivial file because no built dances\n'
+		mkdir -p $$(dirname $@) ## FIXME: this is a bit dirty
 	  jq -n '{dances:{}}' > $@
 	fi
 
@@ -251,6 +252,7 @@ $(website-output)/tunes.raw.json: $(addsuffix .raw.json, $(built_tunes))
 	  jq -s 'map({(.slug): (.tune)}) | .+[{}] | add | {tunes:., root:"."}' $^ > $@
 	else
 	  printf '  => trivial file because no built tunes\n'
+	  mkdir -p $$(dirname $@) ## FIXME: this is a bit dirty
 	  jq -n '{tunes:{}, root:"."}' > $@
 	fi
 


### PR DESCRIPTION
This makes it actually possible to build with empty lists, to do something like:

```
make dances= books= tunes=my-tune
```