### PR TITLE
Fix “Forty Bars of Clouds”

### DIFF
--- a/database/tune/forty-bars-of-clouds.yaml
+++ b/database/tune/forty-bars-of-clouds.yaml
@@ -65,8 +65,8 @@ content: |
 
       f e f g a c,4 c8 |
       f e f g a g f e |
-      \tuplet 3/4 { b4 c8 } \tuplet 3/4 { d4 c8 } |
-      \tuplet 3/4 { b4 c8 } b2 |
+      b4. c8 d4. c8 |
+      b4. c8 b2 |
       \bar "||" \break
 
       c4 c8 d e g,4 g8 |


### PR DESCRIPTION
Until recently, bars 31-32 indicated:

![image](https://github.com/Niols/scd.niols.fr/assets/5920602/8931ad3f-f322-4ceb-b7af-f043f719e218)

which is not actually what I am playing. It has been fixed on Dancelor and is now fixed here, going to:

![image](https://github.com/Niols/scd.niols.fr/assets/5920602/e9a7b61d-46d0-41aa-866c-c8715a8cff6e)

instead.