### PR TITLE
Improve wording of “Emmy and Matt's Wedding”

### DIFF
--- a/database/dance/emmy-and-matt-s-wedding.yaml
+++ b/database/dance/emmy-and-matt-s-wedding.yaml
@@ -46,7 +46,7 @@ instructions:
     starts: 21
     ends: 24
     content: |
-      4th couple, giving left hands, cross down to fourth place while 3rd couple
+      4th couple, without giving hands, cross down to fourth place while 3rd couple
       cast up to second place, to finish in the order 2, 3, 1, 4.
 
   - type: phrase

--- a/database/dance/emmy-and-matt-s-wedding.yaml
+++ b/database/dance/emmy-and-matt-s-wedding.yaml
@@ -18,36 +18,42 @@ instructions:
 
   - type: phrase
     starts: 1
+    ends: 4
+    content: |
+      1st couple cast off one place while 4th couple cast up one place. 2nd
+      couple step up and 3rd couple step down on bars 3-4.
+
+  - type: phrase
+    starts: 5
     ends: 8
     content: |
-      1st and 4th couples cast in four bars. 2nd couple step up and 3rd couple
-      step down on bars 3-4. 1st and 4th couples dance a half figure of eight
-      around 2nd and 3rd couples.
+      1st couple dance a half figure of eight round 2nd couple while 4th couple
+      dance a half figure of eight round 3rd couple.
 
   - type: phrase
     starts: 9
     ends: 16
     content: |
-      1st and 4th couples in second and third places dance set and rotate.
+      1st and 4th couples set and rotate.
 
   - type: phrase
     starts: 17
     ends: 20
     content: |
-      1st couple turn both hands one and a half times in four bars.
+      1st couple, giving both hands, turn one and a half times.
 
   - type: phrase
     starts: 21
     ends: 24
     content: |
-      4th couple cross down to fourth place while 3rd couple cast up to second
-      place.
+      4th couple, giving left hands, cross down to fourth place while 3rd couple
+      cast up to second place, to finish in the order 2, 3, 1, 4.
 
   - type: phrase
     starts: 25
     ends: 32
     content: |
-      3rd and 1st couples dance a poussette right round.
+      3rd and 1st couples dance a poussette.
 
   - type: kind
     kind: Reel
@@ -56,62 +62,51 @@ instructions:
     starts: 33
     ends: 40
     content: |
-      1st couple dance a figure of love around the 3rd and 4th couples:
-    instructions:
-      - type: phrase
-        starts: 33
-        ends: 36
-        content: |
-          1st couple dance a half figure of eight, woman up between 3rd couple,
-          man down between 4th couple, finishing by meeting in the centre of the
-          dance and briefly touching both hands.
-      - type: phrase
-        starts: 37
-        ends: 40
-        content: |
-          1st couple pull back left shoulder and cast, woman down and man up;
-          1st woman dances up between 4th couple while 1st man dances down
-          between 3rd couple; both finish in third place on own sides facing
-          out.
+      1st couple dance the »figure of love«: 1st woman dances up between 3rd
+      couple and casts off round 3rd man, while 1st man dances down between 4th
+      couple and casts up round 4th woman. 1st couple meet in the middle of the
+      set, touch both hands, then, pulling back left shoulders, 1st woman casts
+      off round 4th man, while 1st man casts up round 3rd woman. 1st couple
+      finish in third place on own sides facing out.
 
   - type: phrase
     starts: 41
     ends: 48
     content: |
-      1st, 3rd and 4th couples dance a promenade chain progression, finishing in
-      order 2, 4, 1, 3, with 1st couple in the middle of the set, 1st man facing
-      3rd woman in fourth place and 1st woman facing 4th man in second place.
+      3rd, 1st and 4th couples dance a chain progression for three couples. 1st
+      couple finish back to back in the middle of the set, 1st woman facing 4th
+      man and 1st man facing 3rd woman.
 
   - type: phrase
     starts: 49
     ends: 52
     content: |
-      1st couple dance a half reel of four with 3rd woman and 4th man, passing
-      by the right to finish with 1st man facing 4th woman in second place and
-      1st woman facing 3rd man in fourth place.
+      1st couple dance a half diagonal reel of four with 4th man and 3rd woman,
+      passing by the right at the end to finish, 1st man facing 4th woman and
+      1st woman facing 3rd man.
 
   - type: phrase
     starts: 53
     ends: 56
     content: |
-      1st couple repeat with 4th woman and 3rd man, finishing with 1st man
-      facing 3rd woman on the men's line and 1st woman facing 4th man on the
-      women's line.
+      1st couple dance a half diagonal reel of four with 4th woman and 3rd man,
+      passing by the right at the end to finish, 1st man facing 3rd woman and
+      1st woman facing 4th man.
 
   - type: phrase
     starts: 57
     ends: 60
     content: |
-      1st couple repeat with 3rd woman and 4th man, finishing with 1st man
-      facing 4th woman on the men's line and 1st woman facing 3rd man on the
-      women's line.
+      1st couple dance a half diagonal reel of four with 3rd woman and 4th man,
+      passing by the right at the end to finish, 1st woman facing 3rd man and
+      1st man facing 4th woman.
 
   - type: phrase
     starts: 61
     ends: 64
     content: |
-      1st couple repeat with 4th woman and 3rd man, finishing in third place on
-      own sides.
+      1st couple dance a half diagonal reel of four with 3rd man and 4th woman,
+      to finish in third place on own sides in the order 2, 4, 1, 3.
 
   - type: repeat
     kind: from new positions

--- a/database/dance/emmy-s-wedding.yaml
+++ b/database/dance/emmy-s-wedding.yaml
@@ -41,7 +41,7 @@ instructions:
     starts: 21
     ends: 24
     content: |
-      4th couple, giving left hands, cross down to fourth place while 3rd couple
+      4th couple, without giving hands, cross down to fourth place while 3rd couple
       cast up to second place, to finish in the order 2, 3, 1, 4.
 
   - type: phrase

--- a/database/dance/emmy-s-wedding.yaml
+++ b/database/dance/emmy-s-wedding.yaml
@@ -13,52 +13,47 @@ tunes:
 instructions:
   - type: phrase
     starts: 1
+    ends: 4
+    content: |
+      1st couple cast off one place while 4th couple cast up one place. 2nd
+      couple step up and 3rd couple step down on bars 3-4.
+
+  - type: phrase
+    starts: 5
     ends: 8
     content: |
-      1st and 4th couples cast in four bars. 2nd couple step up and 3rd couple
-      step down on bars 3-4. 1st and 4th couples dance a half figure of eight
-      around 2nd and 3rd couples.
+      1st couple dance a half figure of eight round 2nd couple while 4th couple
+      dance a half figure of eight round 3rd couple.
 
   - type: phrase
     starts: 9
     ends: 16
     content: |
-      1st and 4th couples in second and third places dance set and rotate.
+      1st and 4th couples set and rotate.
 
   - type: phrase
     starts: 17
     ends: 20
     content: |
-      1st couple turn both hands one and a half times in four bars.
+      1st couple, giving both hands, turn one and a half times.
 
   - type: phrase
     starts: 21
     ends: 24
     content: |
-      4th couple cross down to fourth place while 3rd couple cast up to second
-      place.
+      4th couple, giving left hands, cross down to fourth place while 3rd couple
+      cast up to second place, to finish in the order 2, 3, 1, 4.
 
   - type: phrase
     starts: 25
     ends: 32
     content: |
-      1st couple dance a figure of love around the 3rd and 4th couples:
-    instructions:
-      - type: phrase
-        starts: 25
-        ends: 28
-        content: |
-          1st couple dance a half figure of eight, woman up between 3rd couple,
-          man down between 4th couple, finishing by meeting in the centre of the
-          dance and briefly touching both hands.
-      - type: phrase
-        starts: 29
-        ends: 32
-        content: |
-          1st couple pull back left shoulder and cast, woman down and man up;
-          1st woman dances up between 4th couple while 1st man dances down
-          between 3rd couple; both finish in third place on own sides facing
-          out.
+      1st couple dance the »figure of love«: 1st woman dances up between 3rd
+      couple and casts off round 3rd man, while 1st man dances down between 4th
+      couple and casts up round 4th woman. 1st couple meet in the middle of the
+      set, touch both hands, then, pulling back left shoulders, 1st woman casts
+      off round 4th man, while 1st man casts up round 3rd woman. 1st couple
+      finish in third place on own sides facing out.
 
   - type: phrase
     starts: 33

--- a/database/dance/matt-s-wedding.yaml
+++ b/database/dance/matt-s-wedding.yaml
@@ -41,7 +41,7 @@ instructions:
     starts: 21
     ends: 24
     content: |
-      4th couple, giving left hands, cross down to fourth place while 3rd couple
+      4th couple, without giving hands, cross down to fourth place while 3rd couple
       cast up to second place, to finish in the order 2, 3, 1, 4.
 
   - type: phrase

--- a/database/dance/matt-s-wedding.yaml
+++ b/database/dance/matt-s-wedding.yaml
@@ -13,52 +13,47 @@ tunes:
 instructions:
   - type: phrase
     starts: 1
+    ends: 4
+    content: |
+      1st couple cast off one place while 4th couple cast up one place. 2nd
+      couple step up and 3rd couple step down on bars 3-4.
+
+  - type: phrase
+    starts: 5
     ends: 8
     content: |
-      1st and 4th couples cast in four bars. 2nd couple step up and 3rd couple
-      step down on bars 3-4. 1st and 4th couples dance a half figure of eight
-      around 2nd and 3rd couples.
+      1st couple dance a half figure of eight round 2nd couple while 4th couple
+      dance a half figure of eight round 3rd couple.
 
   - type: phrase
     starts: 9
     ends: 16
     content: |
-      1st and 4th couples in second and third places dance set and rotate.
+      1st and 4th couples set and rotate.
 
   - type: phrase
     starts: 17
     ends: 20
     content: |
-      1st couple turn both hands one and a half times in four bars.
+      1st couple, giving both hands, turn one and a half times.
 
   - type: phrase
     starts: 21
     ends: 24
     content: |
-      4th couple cross down to fourth place while 3rd couple cast up to second
-      place.
+      4th couple, giving left hands, cross down to fourth place while 3rd couple
+      cast up to second place, to finish in the order 2, 3, 1, 4.
 
   - type: phrase
     starts: 25
     ends: 32
     content: |
-      1st couple dance a figure of love around the 3rd and 4th couples:
-    instructions:
-      - type: phrase
-        starts: 25
-        ends: 28
-        content: |
-          1st couple dance a half figure of eight, woman up between 3rd couple,
-          man down between 4th couple, finishing by meeting in the centre of the
-          dance and briefly touching both hands.
-      - type: phrase
-        starts: 29
-        ends: 32
-        content: |
-          1st couple pull back left shoulder and cast, woman down and man up;
-          1st woman dances up between 4th couple while 1st man dances down
-          between 3rd couple; both finish in third place on own sides facing
-          out.
+      1st couple dance the »figure of love«: 1st woman dances up between 3rd
+      couple and casts off round 3rd man, while 1st man dances down between 4th
+      couple and casts up round 4th woman. 1st couple meet in the middle of the
+      set, touch both hands, then, pulling back left shoulders, 1st woman casts
+      off round 4th man, while 1st man casts up round 3rd woman. 1st couple
+      finish in third place on own sides facing out.
 
   - type: phrase
     starts: 33


### PR DESCRIPTION
...and its variants. The new wording is based on Tom's proof-reading of “Emmy
and Matt's Wedding” as a candidate to publication in the Paris Book 3.

Here are a few comments by Tom:

- On bars 21-24: “The hand to use in the cross down was not specified. I am
  assuming left hands, but perhaps check with the devisor?” 
  
- On bars 33-40: “For consistency I have used here the wording for the figure of
  love as in Paris Book 2 in Love is in the Air.”

- On bars 41-48: “I’m assuming 1st man and 1st woman finish at the end of bar 48
  back to back in the middle of the set facing “corners”? It would be possible
  though to start the first half diagonal reel from the sides and if is the
  intention the wording needs to be changed.”

- On bars 49-64: “If I’ve understood these “Mairie’s Wedding” half reels
  correctly, the 1st couple don’t pass by the right at the end as they will
  already be on their own sides?”

In particular, the cross down with left hand needs to be clarified. I have
contacted the deviser to discuss this.